### PR TITLE
CompilerUtils is an enum

### DIFF
--- a/compiler/src/main/java/net/openhft/compiler/CompilerUtils.java
+++ b/compiler/src/main/java/net/openhft/compiler/CompilerUtils.java
@@ -36,8 +36,8 @@ import java.util.Arrays;
 /**
  * This class support loading and debugging Java Classes dynamically.
  */
-public enum CompilerUtils {
-    ;
+public class CompilerUtils {
+
     public static final boolean DEBUGGING = isDebug();
     public static final CachedCompiler CACHED_COMPILER = new CachedCompiler(null, null);
 


### PR DESCRIPTION
The CompilerUtils appereantly is an enum for no reason.
