### PR TITLE
Fix README formatting

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@ image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Java-Runt
 This takes a String, compiles it and loads it returning you a class from what you built.  
 By default it uses the current ClassLoader.  It supports nested classes, otherwise builds one class at a time.
 
-== On maven central
+== On Maven Central
 
 You can include in your project with
 
@@ -44,7 +44,7 @@ String javaCode = "package mypackage;\n" +
 Class aClass = CompilerUtils.CACHED_COMPILER.loadFromJava(className, javaCode);
 Runnable runner = (Runnable) aClass.newInstance();
 runner.run();
-````
+```
      
 I suggest making your class implement a KnownInterface of your choice as this will allow you to call/manipulate instances of you generated class.
 
@@ -52,7 +52,7 @@ Another more hacky way is to use this to override a class, provided it hasn't be
 This means you can redefine an existing class and provide the methods and fields used match,
 you have compiler redefine a class and code already compiled to use the class will still work.
 
-## Using the CachedCompiler.
+== Using the CachedCompiler.
 
 In this example, you can configure the compiler to write the files to a specific directory when you are in debug mode.
        


### PR DESCRIPTION
Fixes incorrect <code>\`\`\`\`</code> (four backticks) for closing the code block. Currently that erroneously causes everything below to be shown as code block.