### PR TITLE
Support providing `DiagnosticListener` for compiling

### DIFF
--- a/src/main/java/net/openhft/compiler/CompilerUtils.java
+++ b/src/main/java/net/openhft/compiler/CompilerUtils.java
@@ -33,7 +33,7 @@ import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
@@ -42,11 +42,15 @@ import java.util.Arrays;
 public enum CompilerUtils {
     ; // none
     public static final boolean DEBUGGING = isDebug();
+    /**
+     * Singleton {@link CachedCompiler}. Uses default {@code javac} options of
+     * {@link CachedCompiler#CachedCompiler(File, File)}, and does not write {@code .java}
+     * source files and {@code .class} files to the file system.
+     */
     public static final CachedCompiler CACHED_COMPILER = new CachedCompiler(null, null);
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompilerUtils.class);
     private static final Method DEFINE_CLASS_METHOD;
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
     private static final String JAVA_CLASS_PATH = "java.class.path";
     static JavaCompiler s_compiler;
     static StandardJavaFileManager s_standardJavaFileManager;
@@ -160,7 +164,7 @@ public enum CompilerUtils {
      */
     public static Class<?> defineClass(@Nullable ClassLoader classLoader, @NotNull String className, @NotNull byte[] bytes) {
         try {
-            return (Class) DEFINE_CLASS_METHOD.invoke(classLoader, className, bytes, 0, bytes.length);
+            return (Class<?>) DEFINE_CLASS_METHOD.invoke(classLoader, className, bytes, 0, bytes.length);
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         } catch (InvocationTargetException e) {
@@ -173,7 +177,7 @@ public enum CompilerUtils {
         if (resourceName.startsWith("="))
             return resourceName.substring(1);
         StringWriter sw = new StringWriter();
-        Reader isr = new InputStreamReader(getInputStream(resourceName), UTF_8);
+        Reader isr = new InputStreamReader(getInputStream(resourceName), StandardCharsets.UTF_8);
         try {
             char[] chars = new char[8 * 1024];
             int len;
@@ -187,11 +191,7 @@ public enum CompilerUtils {
 
     @NotNull
     private static String decodeUTF8(@NotNull byte[] bytes) {
-        try {
-            return new String(bytes, UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     @Nullable
@@ -230,11 +230,7 @@ public enum CompilerUtils {
 
     @NotNull
     private static byte[] encodeUTF8(@NotNull String text) {
-        try {
-            return text.getBytes(UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            throw new AssertionError(e);
-        }
+        return text.getBytes(StandardCharsets.UTF_8);
     }
 
     public static boolean writeBytes(@NotNull File file, @NotNull byte[] bytes) {

--- a/src/test/java/net/openhft/compiler/CompilerTest.java
+++ b/src/test/java/net/openhft/compiler/CompilerTest.java
@@ -25,12 +25,17 @@ import org.junit.Test;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.tools.Diagnostic;
 
 public class CompilerTest extends TestCase {
     static final File parent;
@@ -47,8 +52,30 @@ public class CompilerTest extends TestCase {
         }
     }
 
+    private CachedCompiler compiler;
+    private URLClassLoader classLoader;
+
+    @Override
+    protected void setUp() throws Exception {
+        // Create new compiler and class loader to prevent tests from affecting each other
+        compiler = new CachedCompiler(null, null);
+        classLoader = new URLClassLoader(new URL[0]);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        compiler.close();
+        classLoader.close();
+    }
+
     public static void main(String[] args) throws Throwable {
-        new CompilerTest().test_compiler();
+        CompilerTest compilerTest = new CompilerTest();
+        try {
+            compilerTest.setUp();
+            compilerTest.test_compiler();
+        } finally {
+            compilerTest.tearDown();
+        }
     }
 
     public void test_compiler() throws Throwable {
@@ -62,7 +89,7 @@ public class CompilerTest extends TestCase {
         // this writes the file to disk only when debugging is enabled.
         CachedCompiler cc = CompilerUtils.DEBUGGING ?
                 new CachedCompiler(new File(parent, "target/generated-test-sources"), new File(parent, "target/test-classes")) :
-                CompilerUtils.CACHED_COMPILER;
+                compiler;
 
         String text = "generated test " + new Date();
         try {
@@ -109,9 +136,7 @@ public class CompilerTest extends TestCase {
         }
     }
 
-    public void test_fromFile()
-            throws ClassNotFoundException, IOException, IllegalAccessException, InstantiationException,
-            NoSuchMethodException, InvocationTargetException, NoSuchFieldException {
+    public void test_fromFile() throws Exception {
         Class<?> clazz = CompilerUtils.loadFromResource("eg.FooBarTee2", "eg/FooBarTee2.jcf");
         // turn off System.out
         PrintStream out = System.out;
@@ -121,7 +146,7 @@ public class CompilerTest extends TestCase {
                 public void write(int b) throws IOException {
                 }
             }));
-            final Constructor stringConstructor = clazz.getConstructor(String.class);
+            final Constructor<?> stringConstructor = clazz.getConstructor(String.class);
             long start = 0;
             for (int i = -RUNS / 10; i < RUNS; i++) {
                 if (i == 0) start = System.nanoTime();
@@ -160,8 +185,8 @@ public class CompilerTest extends TestCase {
                 }
             }));
 
-            CompilerUtils.CACHED_COMPILER.loadFromJava(
-                    getClass().getClassLoader(), "TestClass", "clazz TestClass {}",
+            compiler.loadFromJava(
+                    classLoader, "TestClass", "clazz TestClass {}",
                     new PrintWriter(writer));
             fail("Should have failed to compile");
         } catch (ClassNotFoundException e) {
@@ -205,8 +230,8 @@ public class CompilerTest extends TestCase {
                 }
             }));
 
-            CompilerUtils.CACHED_COMPILER.loadFromJava(
-                    getClass().getClassLoader(), "TestClass", "class TestClass {}",
+            compiler.loadFromJava(
+                    classLoader, "TestClass", "class TestClass {}",
                     new PrintWriter(writer));
         } finally {
             System.setOut(out);
@@ -226,6 +251,47 @@ public class CompilerTest extends TestCase {
         final PrintStream err = System.err;
         final StringWriter writer = new StringWriter();
 
+        // Enable lint; otherwise compiler produces no Warning diagnostics but only Note, saying
+        // that `-Xlint:deprecation` should be used
+        final List<String> options = Arrays.asList("-Xlint:deprecation");
+        try (CachedCompiler compiler = new CachedCompiler(null, null, options)) {
+            System.setOut(new PrintStream(new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    usedSysOut.set(true);
+                }
+            }));
+            System.setErr(new PrintStream(new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    usedSysErr.set(true);
+                }
+            }));
+
+            compiler.loadFromJava(
+                    classLoader, "TestClass",
+                    // definition with a mandatory warning for deprecated `Date.getDay()`
+                    "import java.util.Date; class TestClass { int i = new Date().getDay(); }",
+                    new PrintWriter(writer));
+        } finally {
+            System.setOut(out);
+            System.setErr(err);
+        }
+
+        assertFalse(usedSysOut.get());
+        assertFalse(usedSysErr.get());
+        assertEquals("", writer.toString());
+    }
+
+    public void test_settingDiagnosticListenerWithCompilerErrors() throws Exception {
+        final AtomicBoolean usedSysOut = new AtomicBoolean(false);
+        final AtomicBoolean usedSysErr = new AtomicBoolean(false);
+
+        final PrintStream out = System.out;
+        final PrintStream err = System.err;
+        final StringWriter writer = new StringWriter();
+        final List<Diagnostic<?>> diagnostics = Collections.synchronizedList(new ArrayList<>());
+
         try {
             System.setOut(new PrintStream(new OutputStream() {
                 @Override
@@ -240,11 +306,15 @@ public class CompilerTest extends TestCase {
                 }
             }));
 
-            CompilerUtils.CACHED_COMPILER.loadFromJava(
-                    getClass().getClassLoader(), "TestClass",
-                    // definition with a mandatory warning
-                    "class TestClass { int i = new Date().getDay(); }",
-                    new PrintWriter(writer));
+            compiler.loadFromJava(
+                    classLoader,
+                    "TestClass",
+                    "clazz TestClass {}",
+                    new PrintWriter(writer),
+                    diagnostics::add);
+            fail("Should have failed to compile");
+        } catch (ClassNotFoundException e) {
+            // expected
         } finally {
             System.setOut(out);
             System.setErr(err);
@@ -252,7 +322,62 @@ public class CompilerTest extends TestCase {
 
         assertFalse(usedSysOut.get());
         assertFalse(usedSysErr.get());
+        // Diagnostics should have only been reported to listener; not written to output
         assertEquals("", writer.toString());
+
+        assertEquals(1, diagnostics.size());
+        Diagnostic<?> diagnostic = diagnostics.get(0);
+        assertEquals(Diagnostic.Kind.ERROR, diagnostic.getKind());
+        assertEquals(1, diagnostic.getLineNumber());
+    }
+
+    public void test_settingDiagnosticListenerWithWarnings() throws Exception {
+        final AtomicBoolean usedSysOut = new AtomicBoolean(false);
+        final AtomicBoolean usedSysErr = new AtomicBoolean(false);
+
+        final PrintStream out = System.out;
+        final PrintStream err = System.err;
+        final StringWriter writer = new StringWriter();
+        final List<Diagnostic<?>> diagnostics = Collections.synchronizedList(new ArrayList<>());
+
+        // Enable lint; otherwise compiler only produces no Warning diagnostics but only Note, saying
+        // that `-Xlint:unchecked` should be used
+        final List<String> options = Arrays.asList("-Xlint:unchecked");
+        try (CachedCompiler compiler = new CachedCompiler(null, null, options)) {
+            System.setOut(new PrintStream(new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    usedSysOut.set(true);
+                }
+            }));
+            System.setErr(new PrintStream(new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    usedSysErr.set(true);
+                }
+            }));
+
+            compiler.loadFromJava(
+                    classLoader,
+                    "TestClass",
+                    // definition with a mandatory warning for unchecked cast
+                    "import java.util.*; class TestClass { public List<Integer> unsafe(List<?> l) { return (List<Integer>) l; } }",
+                    new PrintWriter(writer),
+                    diagnostics::add);
+        } finally {
+            System.setOut(out);
+            System.setErr(err);
+        }
+
+        assertFalse(usedSysOut.get());
+        assertFalse(usedSysErr.get());
+        // Diagnostics should have only been reported to listener; not written to output
+        assertEquals("", writer.toString());
+
+        assertEquals(1, diagnostics.size());
+        Diagnostic<?> diagnostic = diagnostics.get(0);
+        assertEquals(Diagnostic.Kind.MANDATORY_WARNING, diagnostic.getKind());
+        assertEquals(1, diagnostic.getLineNumber());
     }
 
     public void test_compilerErrorsDoNotBreakNextCompilations() throws Exception {
@@ -261,21 +386,21 @@ public class CompilerTest extends TestCase {
 
         // cause a compiler error
         try {
-            CompilerUtils.CACHED_COMPILER.loadFromJava(
-                    getClass().getClassLoader(), "X", "clazz X {}", quietWriter);
+            compiler.loadFromJava(
+                    classLoader, "X", "clazz X {}", quietWriter);
             fail("Should have failed to compile");
         } catch (ClassNotFoundException e) {
             // expected
         }
 
         // ensure next class can be compiled and used
-        Class<?> testClass = CompilerUtils.CACHED_COMPILER.loadFromJava(
-                getClass().getClassLoader(), "S", "class S {" +
+        Class<?> testClass = compiler.loadFromJava(
+                classLoader, "S", "class S {" +
                         "public static final String s = \"ok\";}");
 
-        Callable callable = (Callable)
-                CompilerUtils.CACHED_COMPILER.loadFromJava(
-                                getClass().getClassLoader(), "OtherClass",
+        Callable<?> callable = (Callable<?>)
+                compiler.loadFromJava(
+                                classLoader, "OtherClass",
                                 "import java.util.concurrent.Callable; " +
                                         "public class OtherClass implements Callable<String> {" +
                                         "public String call() { return S.s; }}")


### PR DESCRIPTION
Resolves #93

Adds a new `CachedCompiler#loadFromJava` overload with `javax.tools.DiagnosticListener` parameter. The behavior of the existing `loadFromJava` methods remains the same.

Also adds Javadoc to some of the methods and constructors.
Edit: Sorry I overlooked that there is already #140 for adding Javadoc. Feel free to merge that first and then I can try to resolve conflicts here and maybe make some small Javadoc adjustments.

Any feedback is appreciated!