### PR TITLE
Clarify JavaSourceFromString Javadoc

### DIFF
--- a/src/main/java/net/openhft/compiler/JavaSourceFromString.java
+++ b/src/main/java/net/openhft/compiler/JavaSourceFromString.java
@@ -23,7 +23,11 @@ import org.jetbrains.annotations.NotNull;
 import javax.tools.SimpleJavaFileObject;
 import java.net.URI;
 
-/* A file object used to represent source coming from a string.
+/*
+ * An internal SimpleJavaFileObject implementation representing Java source
+ * code provided as a String, allowing the Java compiler to read source
+ * directly from memory. Example URI: string:///com/example/Hello.java. The
+ * contents are expected to be UTF-8.
  */
 class JavaSourceFromString extends SimpleJavaFileObject {
     /**
@@ -35,6 +39,7 @@ class JavaSourceFromString extends SimpleJavaFileObject {
      * Constructs a new JavaSourceFromString.
      *
      * @param name the name of the compilation unit represented by this file object
+     *             (annotated with {@link org.jetbrains.annotations.NotNull})
      * @param code the source code for the compilation unit represented by this file object
      */
     JavaSourceFromString(@NotNull String name, String code) {
@@ -43,7 +48,8 @@ class JavaSourceFromString extends SimpleJavaFileObject {
         this.code = code;
     }
 
-    @SuppressWarnings("RefusedBequest")
+    /** Returns the Java source code. */
+    @SuppressWarnings("RefusedBequest") // Directly returns the stored code string, ignoring encoding-error handling because the source is already held in memory.
     @Override
     public CharSequence getCharContent(boolean ignoreEncodingErrors) {
         return code;


### PR DESCRIPTION
## Summary
- describe how `JavaSourceFromString` loads code
- note `@NotNull` usage in constructor
- document UTF-8 assumption for code
- explain why `getCharContent` ignores encoding errors

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*