### PR TITLE
Document closeable output stream

### DIFF
--- a/src/main/java/net/openhft/compiler/CloseableByteArrayOutputStream.java
+++ b/src/main/java/net/openhft/compiler/CloseableByteArrayOutputStream.java
@@ -21,7 +21,15 @@ package net.openhft.compiler;
 import java.io.ByteArrayOutputStream;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * ByteArrayOutputStream that completes a {@link CompletableFuture} when closed.
+ * The future ties into the JDK compiler's asynchronous behaviour so callers can
+ * wait for compiler output.
+ */
 public class CloseableByteArrayOutputStream extends ByteArrayOutputStream {
+    /**
+     * Future completed once the stream is closed, signalling closure.
+     */
     private final CompletableFuture<?> closeFuture = new CompletableFuture<>();
 
     @Override
@@ -29,6 +37,13 @@ public class CloseableByteArrayOutputStream extends ByteArrayOutputStream {
         closeFuture.complete(null);
     }
 
+    /**
+     * Return the future that completes when {@link #close()} is called.  Callers
+     * may block on this to synchronise with the compiler's asynchronous
+     * behaviour.
+     *
+     * @return future signalling stream closure
+     */
     public CompletableFuture<?> closeFuture() {
         return closeFuture;
     }


### PR DESCRIPTION
## Summary
- explain how the output stream's future works
- note field and method behaviour in Javadoc

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*