### PR TITLE
Add brief Javadocs for example accessor methods

### DIFF
--- a/src/test/java/eg/components/Bar.java
+++ b/src/test/java/eg/components/Bar.java
@@ -19,7 +19,13 @@
 package eg.components;
 
 interface Bar {
+    /**
+     * The {@code Tee} component injected into the bar.
+     */
     Tee getTee();
 
+    /**
+     * The integer value supplied when the bar was constructed.
+     */
     int getI();
 }


### PR DESCRIPTION
## Summary
- add short explanations to `getTee()` and `getI()` in the sample `Bar` interface

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*