### PR TITLE
Add Javadoc to Foo example

### DIFF
--- a/src/test/java/eg/components/Foo.java
+++ b/src/test/java/eg/components/Foo.java
@@ -19,12 +19,23 @@
 package eg.components;
 
 @SuppressWarnings("QuestionableName")
+/**
+ * Simple data holder used to demonstrate dynamic compilation.
+ */
 public class Foo {
     public final Bar bar;
     public final Bar copy;
     public final String s;
     public final int i;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param bar  first bar dependency
+     * @param copy second bar dependency
+     * @param s    textual flag for the example
+     * @param i    example value representing some business field
+     */
     public Foo(Bar bar, Bar copy, String s, int i) {
         this.bar = bar;
         this.copy = copy;


### PR DESCRIPTION
## Summary
- document the Foo class purpose
- clarify meaning of the `i` argument in its constructor

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*