### PR TITLE
Add Javadoc for Tee interface

### DIFF
--- a/src/test/java/eg/components/Tee.java
+++ b/src/test/java/eg/components/Tee.java
@@ -18,6 +18,9 @@
 
 package eg.components;
 
+/**
+ * Simple interface from the examples that exposes a string accessor.
+ */
 interface Tee {
     String getS();
 }


### PR DESCRIPTION
## Summary
- document Tee interface

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*