### PR TITLE
Document immutability of TeeImpl

### DIFF
--- a/src/test/java/eg/components/TeeImpl.java
+++ b/src/test/java/eg/components/TeeImpl.java
@@ -18,7 +18,9 @@
 
 package eg.components;
 
+/** Immutable implementation of {@link Tee}. */
 public class TeeImpl implements Tee {
+    /** `s` is final and set via the constructor. */
     final String s;
 
     public TeeImpl(String s) {


### PR DESCRIPTION
## Summary
- document that `TeeImpl` is an immutable `Tee`
- clarify that `s` is final and set via the constructor

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*