### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,5 +1,5 @@
 
-== Copyright 2016-2025 chronicle.software
+== Copyright 2016-2026 chronicle.software
 
 Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <description>Java Runtime Compiler library.</description>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacoco.line.coverage>0.5</jacoco.line.coverage>
         <jacoco.branch.coverage>0.3</jacoco.branch.coverage>

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/main/java/net/openhft/compiler/CloseableByteArrayOutputStream.java
+++ b/src/main/java/net/openhft/compiler/CloseableByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/main/java/net/openhft/compiler/CompilerUtils.java
+++ b/src/main/java/net/openhft/compiler/CompilerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/main/java/net/openhft/compiler/JavaSourceFromString.java
+++ b/src/main/java/net/openhft/compiler/JavaSourceFromString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/main/java/net/openhft/compiler/MyJavaFileManager.java
+++ b/src/main/java/net/openhft/compiler/MyJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/main/java/net/openhft/compiler/internal/package-info.java
+++ b/src/main/java/net/openhft/compiler/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/test/java/eg/FooBarTee.java
+++ b/src/test/java/eg/FooBarTee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg;
 

--- a/src/test/java/eg/components/Bar.java
+++ b/src/test/java/eg/components/Bar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg.components;
 

--- a/src/test/java/eg/components/BarImpl.java
+++ b/src/test/java/eg/components/BarImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg.components;
 

--- a/src/test/java/eg/components/Foo.java
+++ b/src/test/java/eg/components/Foo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg.components;
 

--- a/src/test/java/eg/components/Tee.java
+++ b/src/test/java/eg/components/Tee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg.components;
 

--- a/src/test/java/eg/components/TeeImpl.java
+++ b/src/test/java/eg/components/TeeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package eg.components;
 

--- a/src/test/java/mytest/IntConsumer.java
+++ b/src/test/java/mytest/IntConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package mytest;
 

--- a/src/test/java/mytest/RuntimeCompileTest.java
+++ b/src/test/java/mytest/RuntimeCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package mytest;
 

--- a/src/test/java/net/openhft/compiler/AiRuntimeGuardrailsTest.java
+++ b/src/test/java/net/openhft/compiler/AiRuntimeGuardrailsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
+++ b/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/java/net/openhft/compiler/CompilerTest.java
+++ b/src/test/java/net/openhft/compiler/CompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/java/net/openhft/compiler/CompilerUtilsIoTest.java
+++ b/src/test/java/net/openhft/compiler/CompilerUtilsIoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/java/net/openhft/compiler/MyIntSupplier.java
+++ b/src/test/java/net/openhft/compiler/MyIntSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/java/net/openhft/compiler/MyJavaFileManagerTest.java
+++ b/src/test/java/net/openhft/compiler/MyJavaFileManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.compiler;
 

--- a/src/test/resources/eg/FooBarTee2.jcf
+++ b/src/test/resources/eg/FooBarTee2.jcf
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2025 chronicle.software
+ * Copyright 2014-2026 chronicle.software
  *
  * http://www.higherfrequencytrading.com
  *


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)