### PR TITLE
docs: upgrade http:// to https:// in docs and comments

### DIFF
--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -5,7 +5,7 @@ Licensed under the *Apache License, Version 2.0* (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Closed as standalone housekeeping. Its sole change upgrades an Apache licence URL from HTTP to HTTPS. The useful README badge repair remains in #173; this optional licence edit was omitted.
