### PR TITLE
docs: link the compiler version badge to Maven Central

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Chronicle Software
 :sectnums:
 :source-highlighter: rouge
 
-image:https://img.shields.io/maven-central/v/net.openhft/compiler.svg[]
+image:https://img.shields.io/maven-central/v/net.openhft/compiler.svg[Maven Central,link=https://central.sonatype.com/artifact/net.openhft/compiler]
 image:https://javadoc.io/badge2/net.openhft/compiler/javadoc.svg[]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]
 image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Java-Runtime-Compiler&metric=alert_status[]

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Chronicle Software
 :sectnums:
 :source-highlighter: rouge
 
-image:https://maven-badges.herokuapp.com/maven-central/net.openhft/compiler/badge.svg[]
+image:https://img.shields.io/maven-central/v/net.openhft/compiler.svg[]
 image:https://javadoc.io/badge2/net.openhft/compiler/javadoc.svg[]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]
 image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Java-Runtime-Compiler&metric=alert_status[]


### PR DESCRIPTION
Replace the README version badge with [Shields' Maven Central API](https://shields.io/badges/maven-central-version), add the label `Maven Central`, and make it clickable to [net.openhft:compiler](https://central.sonatype.com/artifact/net.openhft/compiler). [The badge service's migration notice](https://github.com/softwaremill/maven-badges#readme) deprecated the Heroku URL and limited its availability to the end of 2025.

Validation on 9 September 2026: rendered the full README with Asciidoctor 2.0.20 without warnings; checked the rendered badge's destination and the POM coordinate. The badge SVG returned HTTP 200 with a version label, and the artifact page returned HTTP 200 for the intended artifact. `git diff --check` passes. The generated HTML contains the descriptive alternative text and clickable artifact link. The diff remains one README line; Java tests were not rerun for this documentation edit.
