### PR TITLE
CORE-57 - Surface javac diagnostics for runtime compile failures

### DIFF
--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.tools.Diagnostic;
-import javax.tools.DiagnosticListener;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import java.io.*;
@@ -172,13 +171,15 @@ public class CachedCompiler implements Closeable {
                                         @NotNull String javaCode,
                                         final @NotNull PrintWriter writer,
                                         MyJavaFileManager fileManager) {
-        return compileFromJavaResult(className, javaCode, writer, fileManager).classes;
+        return compileFromJava(className, javaCode, writer, fileManager, null);
     }
 
-    private CompilationResult compileFromJavaResult(@NotNull String className,
-                                                    @NotNull String javaCode,
-                                                    final @NotNull PrintWriter writer,
-                                                    MyJavaFileManager fileManager) {
+    @NotNull
+    private Map<String, byte[]> compileFromJava(@NotNull String className,
+                                                @NotNull String javaCode,
+                                                final @NotNull PrintWriter writer,
+                                                MyJavaFileManager fileManager,
+                                                @Nullable StringBuilder diagnostics) {
         validateClassName(className);
         Iterable<? extends JavaFileObject> compilationUnits;
         if (sourceDir != null) {
@@ -193,14 +194,12 @@ public class CachedCompiler implements Closeable {
             javaFileObjects.put(className, new JavaSourceFromString(className, javaCode));
             compilationUnits = new ArrayList<>(javaFileObjects.values()); // To prevent CME from compiler code
         }
-        StringBuffer diagnostics = new StringBuffer();
         // reuse the same file manager to allow caching of jar files
-        boolean ok = s_compiler.getTask(writer, fileManager, new DiagnosticListener<JavaFileObject>() {
-            @Override
-            public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
-                if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
-                    String message = diagnostic.toString();
-                    writer.println(message);
+        boolean ok = s_compiler.getTask(writer, fileManager, diagnostic -> {
+            if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
+                String message = diagnostic.toString();
+                writer.println(message);
+                if (diagnostics != null) {
                     diagnostics.append(message).append(System.lineSeparator());
                 }
             }
@@ -212,11 +211,11 @@ public class CachedCompiler implements Closeable {
                 javaFileObjects.remove(className);
 
             // nothing to return due to compiler error
-            return new CompilationResult(false, Collections.emptyMap(), diagnostics.toString());
+            return Collections.emptyMap();
         } else {
             Map<String, byte[]> result = fileManager.getAllBuffers();
 
-            return new CompilationResult(true, result, diagnostics.toString());
+            return result;
         }
     }
 
@@ -236,49 +235,30 @@ public class CachedCompiler implements Closeable {
                                  @NotNull String className,
                                  @NotNull String javaCode,
                                  @Nullable PrintWriter writer) throws ClassNotFoundException {
-        Map<String, Class<?>> loadedClasses = getOrCreateLoadedClasses(classLoader);
-        Class<?> clazz = getCachedLoadedClass(loadedClasses, className);
+        Class<?> clazz = null;
+        Map<String, Class<?>> loadedClasses;
+        synchronized (loadedClassesMap) {
+            loadedClasses = loadedClassesMap.get(classLoader);
+            if (loadedClasses == null)
+                loadedClassesMap.put(classLoader, loadedClasses = new LinkedHashMap<>());
+            else
+                clazz = loadedClasses.get(className);
+        }
         PrintWriter printWriter = writer == null ? DEFAULT_WRITER : writer;
         if (clazz != null)
             return clazz;
 
-        MyJavaFileManager fileManager = getOrCreateFileManager(classLoader);
-        final Map<String, byte[]> compiled = compileFromJavaOrThrow(className, javaCode, printWriter, fileManager);
-
-        defineCompiledClasses(classLoader, loadedClasses, compiled);
-        return getLoadedClassOrThrow(loadedClasses, className, compiled.keySet());
-    }
-
-    private Map<String, Class<?>> getOrCreateLoadedClasses(@NotNull ClassLoader classLoader) {
-        synchronized (loadedClassesMap) {
-            Map<String, Class<?>> loadedClasses = loadedClassesMap.get(classLoader);
-            if (loadedClasses == null) {
-                loadedClasses = new LinkedHashMap<>();
-                loadedClassesMap.put(classLoader, loadedClasses);
-            }
-            return loadedClasses;
-        }
-    }
-
-    private Class<?> getCachedLoadedClass(Map<String, Class<?>> loadedClasses, String className) {
-        synchronized (loadedClassesMap) {
-            return loadedClasses.get(className);
-        }
-    }
-
-    private MyJavaFileManager getOrCreateFileManager(@NotNull ClassLoader classLoader) {
         MyJavaFileManager fileManager = fileManagerMap.get(classLoader);
         if (fileManager == null) {
             StandardJavaFileManager standardJavaFileManager = s_compiler.getStandardFileManager(null, null, null);
             fileManager = getFileManager(standardJavaFileManager);
             fileManagerMap.put(classLoader, fileManager);
         }
-        return fileManager;
-    }
-
-    private void defineCompiledClasses(@NotNull ClassLoader classLoader,
-                                       Map<String, Class<?>> loadedClasses,
-                                       Map<String, byte[]> compiled) {
+        StringBuilder diagnostics = new StringBuilder();
+        final Map<String, byte[]> compiled = compileFromJava(className, javaCode, printWriter, fileManager, diagnostics);
+        if (!compiled.containsKey(className)) {
+            throw missingCompiledClassException(className, compiled.keySet(), diagnostics.toString());
+        }
         for (Map.Entry<String, byte[]> entry : compiled.entrySet()) {
             String className2 = entry.getKey();
             validateClassName(className2);
@@ -287,7 +267,13 @@ public class CachedCompiler implements Closeable {
                     continue;
             }
             byte[] bytes = entry.getValue();
-            writeClassFileIfConfigured(className2, bytes);
+            if (classDir != null) {
+                String filename = className2.replaceAll("\\.", '\\' + File.separator) + ".class";
+                boolean changed = writeBytes(safeResolve(classDir, filename), bytes);
+                if (changed) {
+                    LOG.info("Updated {} in {}", className2, classDir);
+                }
+            }
 
             synchronized (className2.intern()) { // To prevent duplicate class definition error
                 synchronized (loadedClassesMap) {
@@ -301,43 +287,10 @@ public class CachedCompiler implements Closeable {
                 }
             }
         }
-    }
-
-    private void writeClassFileIfConfigured(String className, byte[] bytes) {
-        if (classDir != null) {
-            String filename = className.replaceAll("\\.", '\\' + File.separator) + ".class";
-            boolean changed = writeBytes(safeResolve(classDir, filename), bytes);
-            if (changed) {
-                LOG.info("Updated {} in {}", className, classDir);
-            }
-        }
-    }
-
-    private Class<?> getLoadedClassOrThrow(Map<String, Class<?>> loadedClasses,
-                                           String className,
-                                           Set<String> compiledClassNames) throws ClassNotFoundException {
-        Class<?> clazz = getCachedLoadedClass(loadedClasses, className);
-        if (clazz == null) {
-            throw new ClassNotFoundException("Compiled class " + className
-                    + " was not defined. Compiled classes: " + compiledClassNames);
+        synchronized (loadedClassesMap) {
+            loadedClasses.put(className, clazz = classLoader.loadClass(className));
         }
         return clazz;
-    }
-
-    private Map<String, byte[]> compileFromJavaOrThrow(@NotNull String className,
-                                                       @NotNull String javaCode,
-                                                       @NotNull PrintWriter printWriter,
-                                                       @NotNull MyJavaFileManager fileManager) throws ClassNotFoundException {
-        CompilationResult compilation = compileFromJavaResult(className, javaCode, printWriter, fileManager);
-        if (!compilation.success) {
-            throw compilationFailedException(className, compilation.diagnostics);
-        }
-
-        Map<String, byte[]> compiled = compilation.classes;
-        if (!compiled.containsKey(className)) {
-            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
-        }
-        return compiled;
     }
 
     /**
@@ -387,23 +340,17 @@ public class CachedCompiler implements Closeable {
         return candidate.toFile();
     }
 
-    private static ClassNotFoundException compilationFailedException(String className, String diagnostics) {
-        String diagnosticText = diagnostics.trim();
-        String message = "Compilation failed for " + className;
-        if (!diagnosticText.isEmpty()) {
-            message += System.lineSeparator() + diagnosticText;
-        }
-        return new ClassNotFoundException(message, new IllegalStateException(message));
-    }
-
     private static ClassNotFoundException missingCompiledClassException(String className,
                                                                        Set<String> compiledClassNames,
                                                                        String diagnostics) {
         String diagnosticText = diagnostics.trim();
-        String message = "Compilation did not produce requested class " + className
-                + ". Compiled classes: " + compiledClassNames;
+        String message;
         if (!diagnosticText.isEmpty()) {
-            message += System.lineSeparator() + diagnosticText;
+            message = "Compilation failed for " + className
+                    + System.lineSeparator() + diagnosticText;
+        } else {
+            message = "Compilation did not produce requested class " + className
+                    + ". Compiled classes: " + compiledClassNames;
         }
         return new ClassNotFoundException(message, new IllegalStateException(message));
     }
@@ -416,17 +363,5 @@ public class CachedCompiler implements Closeable {
                 flush(); // never close System.err
             }
         };
-    }
-
-    private static final class CompilationResult {
-        private final boolean success;
-        private final Map<String, byte[]> classes;
-        private final String diagnostics;
-
-        private CompilationResult(boolean success, Map<String, byte[]> classes, String diagnostics) {
-            this.success = success;
-            this.classes = classes;
-            this.diagnostics = diagnostics;
-        }
     }
 }

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -193,7 +193,7 @@ public class CachedCompiler implements Closeable {
             javaFileObjects.put(className, new JavaSourceFromString(className, javaCode));
             compilationUnits = new ArrayList<>(javaFileObjects.values()); // To prevent CME from compiler code
         }
-        StringBuilder diagnostics = new StringBuilder();
+        StringBuffer diagnostics = new StringBuffer();
         // reuse the same file manager to allow caching of jar files
         boolean ok = s_compiler.getTask(writer, fileManager, new DiagnosticListener<JavaFileObject>() {
             @Override
@@ -236,35 +236,49 @@ public class CachedCompiler implements Closeable {
                                  @NotNull String className,
                                  @NotNull String javaCode,
                                  @Nullable PrintWriter writer) throws ClassNotFoundException {
-        Class<?> clazz = null;
-        Map<String, Class<?>> loadedClasses;
-        synchronized (loadedClassesMap) {
-            loadedClasses = loadedClassesMap.get(classLoader);
-            if (loadedClasses == null)
-                loadedClassesMap.put(classLoader, loadedClasses = new LinkedHashMap<>());
-            else
-                clazz = loadedClasses.get(className);
-        }
+        Map<String, Class<?>> loadedClasses = getOrCreateLoadedClasses(classLoader);
+        Class<?> clazz = getLoadedClass(loadedClasses, className);
         PrintWriter printWriter = writer == null ? DEFAULT_WRITER : writer;
         if (clazz != null)
             return clazz;
 
+        MyJavaFileManager fileManager = getOrCreateFileManager(classLoader);
+        final Map<String, byte[]> compiled = compileFromJavaOrThrow(className, javaCode, printWriter, fileManager);
+
+        defineCompiledClasses(classLoader, loadedClasses, compiled);
+        return getLoadedClassOrThrow(loadedClasses, className, compiled.keySet());
+    }
+
+    private Map<String, Class<?>> getOrCreateLoadedClasses(@NotNull ClassLoader classLoader) {
+        synchronized (loadedClassesMap) {
+            Map<String, Class<?>> loadedClasses = loadedClassesMap.get(classLoader);
+            if (loadedClasses == null) {
+                loadedClasses = new LinkedHashMap<>();
+                loadedClassesMap.put(classLoader, loadedClasses);
+            }
+            return loadedClasses;
+        }
+    }
+
+    private Class<?> getLoadedClass(Map<String, Class<?>> loadedClasses, String className) {
+        synchronized (loadedClassesMap) {
+            return loadedClasses.get(className);
+        }
+    }
+
+    private MyJavaFileManager getOrCreateFileManager(@NotNull ClassLoader classLoader) {
         MyJavaFileManager fileManager = fileManagerMap.get(classLoader);
         if (fileManager == null) {
             StandardJavaFileManager standardJavaFileManager = s_compiler.getStandardFileManager(null, null, null);
             fileManager = getFileManager(standardJavaFileManager);
             fileManagerMap.put(classLoader, fileManager);
         }
-        final CompilationResult compilation = compileFromJavaResult(className, javaCode, printWriter, fileManager);
-        if (!compilation.success) {
-            throw compilationFailedException(className, compilation.diagnostics);
-        }
+        return fileManager;
+    }
 
-        final Map<String, byte[]> compiled = compilation.classes;
-        if (!compiled.containsKey(className)) {
-            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
-        }
-
+    private void defineCompiledClasses(@NotNull ClassLoader classLoader,
+                                       Map<String, Class<?>> loadedClasses,
+                                       Map<String, byte[]> compiled) {
         for (Map.Entry<String, byte[]> entry : compiled.entrySet()) {
             String className2 = entry.getKey();
             validateClassName(className2);
@@ -273,13 +287,7 @@ public class CachedCompiler implements Closeable {
                     continue;
             }
             byte[] bytes = entry.getValue();
-            if (classDir != null) {
-                String filename = className2.replaceAll("\\.", '\\' + File.separator) + ".class";
-                boolean changed = writeBytes(safeResolve(classDir, filename), bytes);
-                if (changed) {
-                    LOG.info("Updated {} in {}", className2, classDir);
-                }
-            }
+            writeClassFileIfConfigured(className2, bytes);
 
             synchronized (className2.intern()) { // To prevent duplicate class definition error
                 synchronized (loadedClassesMap) {
@@ -293,13 +301,43 @@ public class CachedCompiler implements Closeable {
                 }
             }
         }
-        synchronized (loadedClassesMap) {
-            clazz = loadedClasses.get(className);
+    }
+
+    private void writeClassFileIfConfigured(String className, byte[] bytes) {
+        if (classDir != null) {
+            String filename = className.replaceAll("\\.", '\\' + File.separator) + ".class";
+            boolean changed = writeBytes(safeResolve(classDir, filename), bytes);
+            if (changed) {
+                LOG.info("Updated {} in {}", className, classDir);
+            }
         }
+    }
+
+    private Class<?> getLoadedClassOrThrow(Map<String, Class<?>> loadedClasses,
+                                           String className,
+                                           Set<String> compiledClassNames) throws ClassNotFoundException {
+        Class<?> clazz = getLoadedClass(loadedClasses, className);
         if (clazz == null) {
-            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
+            throw new ClassNotFoundException("Compiled class " + className
+                    + " was not defined. Compiled classes: " + compiledClassNames);
         }
         return clazz;
+    }
+
+    private Map<String, byte[]> compileFromJavaOrThrow(@NotNull String className,
+                                                       @NotNull String javaCode,
+                                                       @NotNull PrintWriter printWriter,
+                                                       @NotNull MyJavaFileManager fileManager) throws ClassNotFoundException {
+        CompilationResult compilation = compileFromJavaResult(className, javaCode, printWriter, fileManager);
+        if (!compilation.success) {
+            throw compilationFailedException(className, compilation.diagnostics);
+        }
+
+        Map<String, byte[]> compiled = compilation.classes;
+        if (!compiled.containsKey(className)) {
+            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
+        }
+        return compiled;
     }
 
     /**

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -172,6 +172,13 @@ public class CachedCompiler implements Closeable {
                                         @NotNull String javaCode,
                                         final @NotNull PrintWriter writer,
                                         MyJavaFileManager fileManager) {
+        return compileFromJavaResult(className, javaCode, writer, fileManager).classes;
+    }
+
+    private CompilationResult compileFromJavaResult(@NotNull String className,
+                                                    @NotNull String javaCode,
+                                                    final @NotNull PrintWriter writer,
+                                                    MyJavaFileManager fileManager) {
         validateClassName(className);
         Iterable<? extends JavaFileObject> compilationUnits;
         if (sourceDir != null) {
@@ -186,12 +193,15 @@ public class CachedCompiler implements Closeable {
             javaFileObjects.put(className, new JavaSourceFromString(className, javaCode));
             compilationUnits = new ArrayList<>(javaFileObjects.values()); // To prevent CME from compiler code
         }
+        StringBuilder diagnostics = new StringBuilder();
         // reuse the same file manager to allow caching of jar files
         boolean ok = s_compiler.getTask(writer, fileManager, new DiagnosticListener<JavaFileObject>() {
             @Override
             public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
                 if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
-                    writer.println(diagnostic);
+                    String message = diagnostic.toString();
+                    writer.println(message);
+                    diagnostics.append(message).append(System.lineSeparator());
                 }
             }
         }, options, null, compilationUnits).call();
@@ -202,11 +212,11 @@ public class CachedCompiler implements Closeable {
                 javaFileObjects.remove(className);
 
             // nothing to return due to compiler error
-            return Collections.emptyMap();
+            return new CompilationResult(false, Collections.emptyMap(), diagnostics.toString());
         } else {
             Map<String, byte[]> result = fileManager.getAllBuffers();
 
-            return result;
+            return new CompilationResult(true, result, diagnostics.toString());
         }
     }
 
@@ -245,7 +255,16 @@ public class CachedCompiler implements Closeable {
             fileManager = getFileManager(standardJavaFileManager);
             fileManagerMap.put(classLoader, fileManager);
         }
-        final Map<String, byte[]> compiled = compileFromJava(className, javaCode, printWriter, fileManager);
+        final CompilationResult compilation = compileFromJavaResult(className, javaCode, printWriter, fileManager);
+        if (!compilation.success) {
+            throw compilationFailedException(className, compilation.diagnostics);
+        }
+
+        final Map<String, byte[]> compiled = compilation.classes;
+        if (!compiled.containsKey(className)) {
+            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
+        }
+
         for (Map.Entry<String, byte[]> entry : compiled.entrySet()) {
             String className2 = entry.getKey();
             validateClassName(className2);
@@ -275,7 +294,10 @@ public class CachedCompiler implements Closeable {
             }
         }
         synchronized (loadedClassesMap) {
-            loadedClasses.put(className, clazz = classLoader.loadClass(className));
+            clazz = loadedClasses.get(className);
+        }
+        if (clazz == null) {
+            throw missingCompiledClassException(className, compiled.keySet(), compilation.diagnostics);
         }
         return clazz;
     }
@@ -327,6 +349,27 @@ public class CachedCompiler implements Closeable {
         return candidate.toFile();
     }
 
+    private static ClassNotFoundException compilationFailedException(String className, String diagnostics) {
+        String diagnosticText = diagnostics.trim();
+        String message = "Compilation failed for " + className;
+        if (!diagnosticText.isEmpty()) {
+            message += System.lineSeparator() + diagnosticText;
+        }
+        return new ClassNotFoundException(message, new IllegalStateException(message));
+    }
+
+    private static ClassNotFoundException missingCompiledClassException(String className,
+                                                                       Set<String> compiledClassNames,
+                                                                       String diagnostics) {
+        String diagnosticText = diagnostics.trim();
+        String message = "Compilation did not produce requested class " + className
+                + ". Compiled classes: " + compiledClassNames;
+        if (!diagnosticText.isEmpty()) {
+            message += System.lineSeparator() + diagnosticText;
+        }
+        return new ClassNotFoundException(message, new IllegalStateException(message));
+    }
+
     private static PrintWriter createDefaultWriter() {
         OutputStreamWriter writer = new OutputStreamWriter(System.err, StandardCharsets.UTF_8);
         return new PrintWriter(writer, true) {
@@ -335,5 +378,17 @@ public class CachedCompiler implements Closeable {
                 flush(); // never close System.err
             }
         };
+    }
+
+    private static final class CompilationResult {
+        private final boolean success;
+        private final Map<String, byte[]> classes;
+        private final String diagnostics;
+
+        private CompilationResult(boolean success, Map<String, byte[]> classes, String diagnostics) {
+            this.success = success;
+            this.classes = classes;
+            this.diagnostics = diagnostics;
+        }
     }
 }

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -189,7 +189,7 @@ public class CachedCompiler implements Closeable {
                                         final @NotNull PrintWriter writer,
                                         MyJavaFileManager fileManager,
                                         @Nullable StringBuilder diagnostics,
-                                        @NotNull Diagnostic.Kind diagnosticToCapture) {
+                                        @Nullable Diagnostic.Kind diagnosticToCapture) {
         validateClassName(className);
         Iterable<? extends JavaFileObject> compilationUnits;
         if (sourceDir != null) {
@@ -204,9 +204,10 @@ public class CachedCompiler implements Closeable {
             javaFileObjects.put(className, new JavaSourceFromString(className, javaCode));
             compilationUnits = new ArrayList<>(javaFileObjects.values()); // To prevent CME from compiler code
         }
+        Diagnostic.Kind threshold = diagnosticToCapture == null ? Diagnostic.Kind.ERROR : diagnosticToCapture;
         // reuse the same file manager to allow caching of jar files
         boolean ok = s_compiler.getTask(writer, fileManager, diagnostic -> {
-            if (shouldCaptureDiagnostic(diagnostic.getKind(), diagnosticToCapture)) {
+            if (diagnostic.getKind().ordinal() <= threshold.ordinal()) {
                 String message = diagnostic.toString();
                 writer.println(message);
                 if (diagnostics != null) {
@@ -226,25 +227,6 @@ public class CachedCompiler implements Closeable {
             Map<String, byte[]> result = fileManager.getAllBuffers();
 
             return result;
-        }
-    }
-
-    private static boolean shouldCaptureDiagnostic(Diagnostic.Kind actual, Diagnostic.Kind threshold) {
-        return diagnosticSeverity(actual) <= diagnosticSeverity(threshold);
-    }
-
-    private static int diagnosticSeverity(Diagnostic.Kind kind) {
-        switch (kind) {
-            case ERROR:
-                return 0;
-            case WARNING:
-            case MANDATORY_WARNING:
-                return 1;
-            case NOTE:
-                return 2;
-            case OTHER:
-            default:
-                return 3;
         }
     }
 

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -175,11 +175,21 @@ public class CachedCompiler implements Closeable {
     }
 
     @NotNull
-    private Map<String, byte[]> compileFromJava(@NotNull String className,
-                                                @NotNull String javaCode,
-                                                final @NotNull PrintWriter writer,
-                                                MyJavaFileManager fileManager,
-                                                @Nullable StringBuilder diagnostics) {
+    Map<String, byte[]> compileFromJava(@NotNull String className,
+                                        @NotNull String javaCode,
+                                        final @NotNull PrintWriter writer,
+                                        MyJavaFileManager fileManager,
+                                        @Nullable StringBuilder diagnostics) {
+        return compileFromJava(className, javaCode, writer, fileManager, diagnostics, Diagnostic.Kind.ERROR);
+    }
+
+    @NotNull
+    Map<String, byte[]> compileFromJava(@NotNull String className,
+                                        @NotNull String javaCode,
+                                        final @NotNull PrintWriter writer,
+                                        MyJavaFileManager fileManager,
+                                        @Nullable StringBuilder diagnostics,
+                                        @NotNull Diagnostic.Kind diagnosticToCapture) {
         validateClassName(className);
         Iterable<? extends JavaFileObject> compilationUnits;
         if (sourceDir != null) {
@@ -196,7 +206,7 @@ public class CachedCompiler implements Closeable {
         }
         // reuse the same file manager to allow caching of jar files
         boolean ok = s_compiler.getTask(writer, fileManager, diagnostic -> {
-            if (diagnostic.getKind() == Diagnostic.Kind.ERROR) {
+            if (shouldCaptureDiagnostic(diagnostic.getKind(), diagnosticToCapture)) {
                 String message = diagnostic.toString();
                 writer.println(message);
                 if (diagnostics != null) {
@@ -216,6 +226,25 @@ public class CachedCompiler implements Closeable {
             Map<String, byte[]> result = fileManager.getAllBuffers();
 
             return result;
+        }
+    }
+
+    private static boolean shouldCaptureDiagnostic(Diagnostic.Kind actual, Diagnostic.Kind threshold) {
+        return diagnosticSeverity(actual) <= diagnosticSeverity(threshold);
+    }
+
+    private static int diagnosticSeverity(Diagnostic.Kind kind) {
+        switch (kind) {
+            case ERROR:
+                return 0;
+            case WARNING:
+            case MANDATORY_WARNING:
+                return 1;
+            case NOTE:
+                return 2;
+            case OTHER:
+            default:
+                return 3;
         }
     }
 

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -256,9 +256,7 @@ public class CachedCompiler implements Closeable {
         }
         StringBuilder diagnostics = new StringBuilder();
         final Map<String, byte[]> compiled = compileFromJava(className, javaCode, printWriter, fileManager, diagnostics);
-        if (!compiled.containsKey(className)) {
-            throw missingCompiledClassException(className, compiled.keySet(), diagnostics.toString());
-        }
+        throwIfMissingCompiledClass(className, compiled, diagnostics);
         for (Map.Entry<String, byte[]> entry : compiled.entrySet()) {
             String className2 = entry.getKey();
             validateClassName(className2);
@@ -338,6 +336,14 @@ public class CachedCompiler implements Closeable {
             throw new IllegalArgumentException("Attempted path traversal for " + relativePath);
         }
         return candidate.toFile();
+    }
+
+    private static void throwIfMissingCompiledClass(String className,
+                                                    Map<String, byte[]> compiled,
+                                                    StringBuilder diagnostics) throws ClassNotFoundException {
+        if (!compiled.containsKey(className)) {
+            throw missingCompiledClassException(className, compiled.keySet(), diagnostics.toString());
+        }
     }
 
     private static ClassNotFoundException missingCompiledClassException(String className,

--- a/src/main/java/net/openhft/compiler/CachedCompiler.java
+++ b/src/main/java/net/openhft/compiler/CachedCompiler.java
@@ -237,7 +237,7 @@ public class CachedCompiler implements Closeable {
                                  @NotNull String javaCode,
                                  @Nullable PrintWriter writer) throws ClassNotFoundException {
         Map<String, Class<?>> loadedClasses = getOrCreateLoadedClasses(classLoader);
-        Class<?> clazz = getLoadedClass(loadedClasses, className);
+        Class<?> clazz = getCachedLoadedClass(loadedClasses, className);
         PrintWriter printWriter = writer == null ? DEFAULT_WRITER : writer;
         if (clazz != null)
             return clazz;
@@ -260,7 +260,7 @@ public class CachedCompiler implements Closeable {
         }
     }
 
-    private Class<?> getLoadedClass(Map<String, Class<?>> loadedClasses, String className) {
+    private Class<?> getCachedLoadedClass(Map<String, Class<?>> loadedClasses, String className) {
         synchronized (loadedClassesMap) {
             return loadedClasses.get(className);
         }
@@ -316,7 +316,7 @@ public class CachedCompiler implements Closeable {
     private Class<?> getLoadedClassOrThrow(Map<String, Class<?>> loadedClasses,
                                            String className,
                                            Set<String> compiledClassNames) throws ClassNotFoundException {
-        Class<?> clazz = getLoadedClass(loadedClasses, className);
+        Class<?> clazz = getCachedLoadedClass(loadedClasses, className);
         if (clazz == null) {
             throw new ClassNotFoundException("Compiled class " + className
                     + " was not defined. Compiled classes: " + compiledClassNames);

--- a/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
+++ b/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
@@ -79,16 +79,16 @@ public class CachedCompilerAdditionalTest {
                     Diagnostic.Kind.ERROR);
 
             cachedCompiler.compileFromJava(
-                    "coverage.WarningSampleWarningThreshold",
-                    "package coverage; import java.util.*; public class WarningSampleWarningThreshold { public List<String> value() { List raw = new ArrayList(); return raw; } }",
+                    "coverage.WarningSampleMandatoryWarningThreshold",
+                    "package coverage; import java.util.*; public class WarningSampleMandatoryWarningThreshold { public List<String> value() { List raw = new ArrayList(); return raw; } }",
                     quietWriter,
                     fileManager,
                     warningDiagnostics,
-                    Diagnostic.Kind.WARNING);
+                    Diagnostic.Kind.MANDATORY_WARNING);
 
             assertEquals("Warning diagnostics should not be captured at ERROR threshold",
                     "", errorDiagnostics.toString());
-            assertTrue("Warning diagnostics should be captured at WARNING threshold: " + warningDiagnostics,
+            assertTrue("Warning diagnostics should be captured at MANDATORY_WARNING threshold: " + warningDiagnostics,
                     warningDiagnostics.toString().contains("unchecked"));
         }
     }

--- a/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
+++ b/src/test/java/net/openhft/compiler/CachedCompilerAdditionalTest.java
@@ -5,12 +5,14 @@ package net.openhft.compiler;
 
 import org.junit.Test;
 
+import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
@@ -54,6 +56,40 @@ public class CachedCompilerAdditionalTest {
                     "package coverage; public class Broken { this does not compile }",
                     fileManager);
             assertTrue("Broken source should not produce classes", classes.isEmpty());
+        }
+    }
+
+    @Test
+    public void compileFromJavaCapturesDiagnosticsAtRequestedSeverity() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertNotNull("System compiler required", compiler);
+        try (StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, null, null)) {
+            CachedCompiler cachedCompiler = new CachedCompiler(null, null, Arrays.asList("-g", "-Xlint:unchecked"));
+            MyJavaFileManager fileManager = new MyJavaFileManager(standardManager);
+            StringBuilder errorDiagnostics = new StringBuilder();
+            StringBuilder warningDiagnostics = new StringBuilder();
+            PrintWriter quietWriter = new PrintWriter(new StringWriter());
+
+            cachedCompiler.compileFromJava(
+                    "coverage.WarningSampleErrorThreshold",
+                    "package coverage; import java.util.*; public class WarningSampleErrorThreshold { public List<String> value() { List raw = new ArrayList(); return raw; } }",
+                    quietWriter,
+                    fileManager,
+                    errorDiagnostics,
+                    Diagnostic.Kind.ERROR);
+
+            cachedCompiler.compileFromJava(
+                    "coverage.WarningSampleWarningThreshold",
+                    "package coverage; import java.util.*; public class WarningSampleWarningThreshold { public List<String> value() { List raw = new ArrayList(); return raw; } }",
+                    quietWriter,
+                    fileManager,
+                    warningDiagnostics,
+                    Diagnostic.Kind.WARNING);
+
+            assertEquals("Warning diagnostics should not be captured at ERROR threshold",
+                    "", errorDiagnostics.toString());
+            assertTrue("Warning diagnostics should be captured at WARNING threshold: " + warningDiagnostics,
+                    warningDiagnostics.toString().contains("unchecked"));
         }
     }
 

--- a/src/test/java/net/openhft/compiler/CachedCompilerModuleClassLoaderDiagnosticsTest.java
+++ b/src/test/java/net/openhft/compiler/CachedCompilerModuleClassLoaderDiagnosticsTest.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
-public class CachedCompilerModuleClassLoaderReproTest {
+public class CachedCompilerModuleClassLoaderDiagnosticsTest {
 
     @Test
     public void moduleLikeLoaderCanLoadClassAfterSuccessfulDefineClass() throws Exception {
@@ -102,7 +102,7 @@ public class CachedCompilerModuleClassLoaderReproTest {
         private static final String APP_PREFIX = "app.";
 
         ModuleLikeClassLoader() {
-            super(CachedCompilerModuleClassLoaderReproTest.class.getClassLoader());
+            super(CachedCompilerModuleClassLoaderDiagnosticsTest.class.getClassLoader());
         }
 
         @Override

--- a/src/test/java/net/openhft/compiler/CachedCompilerModuleClassLoaderReproTest.java
+++ b/src/test/java/net/openhft/compiler/CachedCompilerModuleClassLoaderReproTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.compiler;
+
+import org.junit.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class CachedCompilerModuleClassLoaderReproTest {
+
+    @Test
+    public void moduleLikeLoaderCanLoadClassAfterSuccessfulDefineClass() throws Exception {
+        ModuleLikeClassLoader loader = new ModuleLikeClassLoader();
+        CachedCompiler compiler = new CachedCompiler(null, null);
+
+        Class<?> clazz = compiler.loadFromJava(loader,
+                "app.Generated",
+                "package app; public class Generated { public int value() { return 42; } }");
+
+        assertEquals("app.Generated", clazz.getName());
+        assertSame(clazz, loader.loadClass("app.Generated"));
+        assertEquals(42, clazz.getDeclaredMethod("value").invoke(clazz.getDeclaredConstructor().newInstance()));
+    }
+
+    @Test
+    public void compileFailureForLoaderOnlyDependencyReportsJavacDiagnostics() throws Exception {
+        ModuleLikeClassLoader loader = new ModuleLikeClassLoader();
+        defineLoaderOnlyDependency(loader);
+
+        assertSame("Sanity check: the supplied class loader can see the dependency",
+                loader.loadClass("app.Dto"),
+                Class.forName("app.Dto", false, loader));
+
+        CachedCompiler compiler = new CachedCompiler(null, null);
+        StringWriter diagnostics = new StringWriter();
+
+        ClassNotFoundException thrown = assertThrows(ClassNotFoundException.class,
+                () -> compiler.loadFromJava(loader,
+                        "app.GeneratedUsesDto",
+                        "package app; public class GeneratedUsesDto { app.Dto dto; }",
+                        new PrintWriter(diagnostics)));
+
+        assertTrue("Thrown exception should identify compilation failure: " + thrown.getMessage(),
+                thrown.getMessage().contains("Compilation failed for app.GeneratedUsesDto"));
+        assertTrue("Thrown exception should include javac missing-symbol diagnostics: " + thrown.getMessage(),
+                thrown.getMessage().contains("cannot find symbol"));
+        assertTrue("Thrown exception should include the dependency javac could not resolve: " + thrown.getMessage(),
+                thrown.getMessage().contains("Dto"));
+        assertNotNull("Thrown exception should carry a diagnostic cause", thrown.getCause());
+        assertTrue("javac diagnostics should mention the dependency that the compiler could not resolve: "
+                        + diagnostics,
+                diagnostics.toString().contains("Dto"));
+        assertNull("The generated class should not have been defined after javac failure",
+                loader.findLoaded("app.GeneratedUsesDto"));
+    }
+
+    @Test
+    public void successfulCompileWithoutRequestedClassReportsMissingOutput() {
+        ModuleLikeClassLoader loader = new ModuleLikeClassLoader();
+        CachedCompiler compiler = new CachedCompiler(null, null);
+
+        ClassNotFoundException thrown = assertThrows(ClassNotFoundException.class,
+                () -> compiler.loadFromJava(loader,
+                        "app.Expected",
+                        "package app; class Different {}"));
+
+        assertTrue("Thrown exception should identify the missing requested class: " + thrown.getMessage(),
+                thrown.getMessage().contains("Compilation did not produce requested class app.Expected"));
+        assertTrue("Thrown exception should identify the class javac actually produced: " + thrown.getMessage(),
+                thrown.getMessage().contains("app.Different"));
+        assertNotNull("Thrown exception should carry a diagnostic cause", thrown.getCause());
+        assertNull("The requested class should not have been defined",
+                loader.findLoaded("app.Expected"));
+    }
+
+    private static void defineLoaderOnlyDependency(ModuleLikeClassLoader loader) throws Exception {
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        assertNotNull("System compiler required", javac);
+
+        try (StandardJavaFileManager standardManager = javac.getStandardFileManager(null, null, null)) {
+            CachedCompiler bytecodeCompiler = new CachedCompiler(null, null);
+            MyJavaFileManager fileManager = new MyJavaFileManager(standardManager);
+            Map<String, byte[]> classes = bytecodeCompiler.compileFromJava(
+                    "app.Dto",
+                    "package app; public class Dto {}",
+                    fileManager);
+            byte[] dtoBytes = classes.get("app.Dto");
+            assertNotNull(dtoBytes);
+            CompilerUtils.defineClass(loader, "app.Dto", dtoBytes);
+        }
+    }
+
+    private static final class ModuleLikeClassLoader extends ClassLoader {
+        private static final String APP_PREFIX = "app.";
+
+        ModuleLikeClassLoader() {
+            super(CachedCompilerModuleClassLoaderReproTest.class.getClassLoader());
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            return loadClass(name, false);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!name.startsWith(APP_PREFIX)) {
+                return super.loadClass(name, resolve);
+            }
+            return findClass(name, resolve);
+        }
+
+        private Class<?> findClass(String name, boolean resolve) throws ClassNotFoundException {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded != null) {
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+            throw new ClassNotFoundException(name + " from [Module \"deployment.repro.war\" from Service Module Loader]");
+        }
+
+        Class<?> findLoaded(String name) {
+            return findLoadedClass(name);
+        }
+    }
+}


### PR DESCRIPTION
# CORE-57 - Surface javac diagnostics for runtime compile failures

## Summary

Surfaces javac diagnostics directly when runtime compilation fails, instead of masking the real compile failure as a generated-class `ClassNotFoundException`.

## Context

`CachedCompiler.compileFromJava(...)` returns an empty map when javac fails. Previously, `CachedCompiler.loadFromJava(...)` did not distinguish that failure from a successful compile with no classes to define, and still called `classLoader.loadClass(className)`.

With module-style classloaders, this can produce a misleading `ClassNotFoundException` for the generated class name, hiding the actual javac diagnostics such as missing symbols or unresolved types.

## Changes

- Added an internal `CompilationResult` path in `CachedCompiler`.
- Preserved the existing map-returning `compileFromJava(...)` behavior.
- Captured javac diagnostics while continuing to write them to the supplied `PrintWriter`.
- Changed `loadFromJava(...)` to throw diagnostic `ClassNotFoundException` immediately when javac compilation fails.
- Added an explicit guard for “compilation succeeded but did not produce the requested class”.
- Returned the cached class after successful `defineClass(...)` instead of falling through to `classLoader.loadClass(...)`.
- Added regression tests for:
  - successful generated-class loading with a module-like classloader
  - loader-only dependency compile failure surfacing javac diagnostics
  - successful compile output missing the requested class

## Verification

```bash
mvn -q -Dtest=CachedCompilerModuleClassLoaderReproTest test
mvn -q -Dtest=CachedCompilerModuleClassLoaderReproTest,CompilerTest,CachedCompilerAdditionalTest test
mvn -q test
```